### PR TITLE
Add hosting note

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
         </div>
 
         <div class="content is-small has-text-centered">
-            <p>This site is hosted by <a href="https://lug.org.uk">Lug.org.uk</a>, which is hosted by <a href="https://bitfolk.com">Bitfolk</a>.</p>
+            <p>This site is hosted by <a href="https://lug.org.uk">Lug.org.uk</a>, who's infrastructure is provided by <a href="https://bitfolk.com/">BitFolk and <a href="http://www.jump.net.uk/">Jump Networks</a>.</p>
         </div>
         
         <div class="content is-small has-text-centered">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
         </div>
 
         <div class="content is-small has-text-centered">
-            <p>This site is hosted by <a href="https://lug.org.uk">Lug.org.uk</a>, who's infrastructure is provided by <a href="https://bitfolk.com/">BitFolk</a>.</p>
+            <p>This site is hosted by <a href="https://lug.org.uk">Lug.org.uk</a>, whose infrastructure is provided by <a href="https://bitfolk.com/">BitFolk</a>.</p>
         </div>
         
         <div class="content is-small has-text-centered">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,6 +18,10 @@
         </div>
 
         <div class="content is-small has-text-centered">
+            <p>This site is hosted by <a href="https://lug.org.uk">Lug.org.uk</a>, which is hosted by <a href="https://bitfolk.com">Bitfolk</a>.</p>
+        </div>
+        
+        <div class="content is-small has-text-centered">
             <p>Except where otherwise attributed, content here is © 2019 OggCamp, a project of <a href="https://publicsoftware.eu/">Public Software CIC</a></p>
         </div>
     </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
         </div>
 
         <div class="content is-small has-text-centered">
-            <p>This site is hosted by <a href="https://lug.org.uk">Lug.org.uk</a>, who's infrastructure is provided by <a href="https://bitfolk.com/">BitFolk and <a href="http://www.jump.net.uk/">Jump Networks</a>.</p>
+            <p>This site is hosted by <a href="https://lug.org.uk">Lug.org.uk</a>, who's infrastructure is provided by <a href="https://bitfolk.com/">BitFolk</a>.</p>
         </div>
         
         <div class="content is-small has-text-centered">


### PR DESCRIPTION
I mentioned on bitfolk's mailing list this morning that I had helped to port the old oggcamp site to lug.org.uk which is hosted by bitfolk, and Popey mentioned that we should have had a footer to mention it. This PR acts on that suggestion. It might need a tweak to make it look right?